### PR TITLE
make deferred_config an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ This project is setup with two development tools:
 
 ## Configure
 
-This library is configured with [`Mix.Config`](https://hexdocs.pm/mix/Mix.Config.html#content). It supports Phoenix-style system tuples to dynamically read its configuration from the environment, which means that it can be configured at runtime (on boot) rather than at compile-time.
+This library is configured with [`Mix.Config`](https://hexdocs.pm/mix/Mix.Config.html#content). It optionally supports Phoenix-style system tuples to dynamically read its configuration from the environment, which means that it can be configured at runtime (on boot) rather than at compile-time.
 
-Whil using the environment is optional, it's the recommended way to configure a [12-factor application](https://12factor.net/), and it allows to reuse the compiled artifacts with different configurations.
+While using the environment is optional, it's the recommended way to configure a [12-factor application](https://12factor.net/) and it allows to reuse the compiled artifacts with different configurations. When using this library in a project, in order to read the configuration from the env you must declare the optional dependency [`deferred_config`](https://github.com/mrluc/deferred_config) in the project mix file.
 
 You can consult the [`config.exs`](https://github.com/deliveroo/routemaster-client-ex/blob/master/config/config.exs) file for the options that should be set in your application's Mix config, and the [`bin/.env.example`](https://github.com/deliveroo/routemaster-client-ex/blob/master/bin/.env.example) file shows which environment variables are supported.
 

--- a/lib/routemaster/application.ex
+++ b/lib/routemaster/application.ex
@@ -10,8 +10,17 @@ defmodule Routemaster.Application do
   def start(_type, _args) do
     import Supervisor.Spec, warn: false
 
-    # load config from the ENV
-    DeferredConfig.populate(:routemaster)
+    if Code.ensure_loaded?(DeferredConfig) do
+      # When used in a project, if the
+      # deferred_config package is included
+      # in the parent application, then load
+      # the configuration from the unix ENV.
+      #
+      # deferred_config is an optional dependency,
+      # and this block is always executed when
+      # working on this library in development.
+      DeferredConfig.populate(:routemaster)
+    end
 
     children = [
       Redis.worker_spec(:data),

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Routemaster.Mixfile do
       {:poison, "~> 3.1"},
       {:tesla, "~> 0.7.1"},
       {:hackney, "~> 1.8"},
-      {:deferred_config, "~> 0.1.1"},
+      {:deferred_config, "~> 0.1.1", optional: true},
 
       {:ex_doc, "~> 0.16", only: :dev},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false},


### PR DESCRIPTION
Host applications have the final say on how the configuration is managed.

This PR marks `deferred_config` as an optional dependency, because it's not polite to bundle by default a dependency that will mess around the OTP application env.