### PR TITLE
Make the cache TTL configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,8 @@ config :routemaster, :drain_url,
 config :routemaster, :service_auth_credentials,
   {:system, "ROUTEMASTER_SERVICE_AUTH_CREDENTIALS"}
 
+config :routemaster, :cache_ttl, "86400"
+
 # These match the hackney defaults and are here just as an example.
 #
 # config :routemaster, :director_http_options,

--- a/lib/routemaster/cache.ex
+++ b/lib/routemaster/cache.ex
@@ -4,10 +4,10 @@ defmodule Routemaster.Cache do
   backed by Redis.
   """
 
+  alias Routemaster.Config
+
   @type fallback :: (() -> any)
 
-  # todo: make this configurable or dynamic
-  @ttl to_string(3600) # seconds
   @redis Routemaster.Redis.cache()
 
   @doc """
@@ -42,7 +42,7 @@ defmodule Routemaster.Cache do
   """
   @spec write(atom | binary, any) :: {:ok, any} | {:error, any}
   def write(key, term) do
-    case @redis.setex(key, @ttl, serialize(term)) do
+    case @redis.setex(key, Config.cache_ttl, serialize(term)) do
       {:ok, "OK"} ->
         {:ok, term}
       {:error, _} = error ->

--- a/lib/routemaster/config.ex
+++ b/lib/routemaster/config.ex
@@ -211,4 +211,15 @@ defmodule Routemaster.Config do
       auth -> {:ok, auth}
     end
   end
+
+
+  @doc """
+  The cache TTL, as an integer number of seconds represented
+  as a string.
+  Defaults to one day (86400 seconds).
+  """
+  @spec cache_ttl() :: binary
+  def cache_ttl do
+    Application.get_env(@app, :cache_ttl, "86400")
+  end
 end

--- a/spec/routemaster/config_spec.exs
+++ b/spec/routemaster/config_spec.exs
@@ -151,4 +151,11 @@ defmodule Routemaster.ConfigSpec do
       expect Config.service_auth_for("unknown.host.com") |> to(eq :error)
     end
   end
+
+
+  describe "cache_ttl" do
+    it "returns an integer number of seconds" do
+      expect Config.cache_ttl |> to(eq "86400")
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/deliveroo/routemaster-client-ex/issues/47.