### PR TITLE
Fix root path check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+Fixes:
+* Ensure that `Plugs.RootPostOnly` does not accidentally block valid requests (it would happen because [`Phoenix.Router.forward/4`](https://hexdocs.pm/phoenix/Phoenix.Router.html#forward/4) does not strip `conn.request_path` when used in scopes.
+
 ## v0.2.0
 
 Enancements:

--- a/lib/routemaster/drain/plugs/root_post_only.ex
+++ b/lib/routemaster/drain/plugs/root_post_only.ex
@@ -21,11 +21,11 @@ defmodule Routemaster.Plugs.RootPostOnly do
   def init(opts), do: opts
 
 
-  def call(conn = %{method: "POST", request_path: "/"}, _opts) do
+  def call(conn = %{method: "POST", path_info: []}, _opts) do
     conn
   end
 
-  def call(conn = %{request_path: "/"}, _opts) do
+  def call(conn = %{path_info: []}, _opts) do
     conn
     |> Conn.send_resp(405, "")
     |> Conn.halt()


### PR DESCRIPTION
Fixes https://github.com/deliveroo/routemaster-client-ex/issues/67

I think this was working fine when just forwarding `/` from the root path, without the scope. This should fix it.